### PR TITLE
Implement Iterable Support

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -11,7 +11,7 @@ var charsMap   = {
   '\'': '\\\'',
   '\\': '\\\\'
 };
-var mapInstance = new Map();
+var iterableSupport = isIterableSupported();
 
 SqlString.escapeId = function escapeId(val, forbidQualified) {
   if (isArrayLike(val)) {
@@ -82,7 +82,7 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
     values = toArray(values);
   }
 
-  if (values instanceof Map) {
+  if (isMap(values)) {
     values = mapToObject(values);
   }
 
@@ -166,7 +166,7 @@ SqlString.bufferToString = function bufferToString(buffer) {
 SqlString.objectToValues = function objectToValues(object, timeZone) {
   var sql = '';
 
-  if (object instanceof Map) {
+  if (isMap(object)) {
     object = mapToObject(object);
   }
 
@@ -227,12 +227,42 @@ function convertTimezone(tz) {
 }
 
 function isArrayLike(val) {
-  return typeof val[Symbol.iterator] === 'function' &&
-         typeof val !== 'string' &&
-         !(val instanceof Map);
+  if (!iterableSupport && Array.isArray(val)) {
+    return true;
+  }
+  if (iterableSupport &&
+      !isMap(val) &&
+      typeof val[Symbol.iterator] === 'function' &&
+      typeof val !== 'string') {
+    return true;
+  }
+  return false;
+}
+
+function isMap(val) {
+  return iterableSupport && val instanceof Map;
 }
 
 function toArray(val) {
+  if (!iterableSupport) return val;
+  if (Array.isArray(val)) return val;
+  if (typeof val.next === 'undefined') {
+    var arr = [];
+    val.forEach(function(key) {
+      arr.push(key);
+    });
+    return arr;
+  }
+  if (typeof Array.from === 'undefined') {
+    var arr = [];
+    var g;
+    while(true){
+      g = val.next();
+      if (g.done) break;
+      arr.push(g.value);
+    }
+    return arr;
+  }
   return Array.from(val);
 }
 
@@ -242,8 +272,13 @@ function mapToObject(map) {
     object[key] = val;
   });
   // if custom toString was implemented, attach to new object
-  if (map.toString !== mapInstance.toString) {
+  if (map.toString !== new Map().toString) {
     object.toString = map.toString.bind(object);
   }
   return object;
+}
+
+function isIterableSupported() {
+  if ('function' === typeof Map && 'function' === typeof Set) return true;
+  return false;
 }

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -13,7 +13,8 @@ var charsMap   = {
 };
 
 SqlString.escapeId = function escapeId(val, forbidQualified) {
-  if (Array.isArray(val)) {
+  if (isIterable(val)) {
+    val = toArray(val);
     var sql = '';
 
     for (var i = 0; i < val.length; i++) {
@@ -41,10 +42,10 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
     case 'object':
       if (val instanceof Date) {
         val = SqlString.dateToString(val, timeZone || 'local');
-      } else if (Array.isArray(val)) {
-        return SqlString.arrayToList(val, timeZone);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
+      } else if (isIterable(val)) {
+        return SqlString.arrayToList(toArray(val), timeZone);
       } else if (stringifyObjects) {
         val = val.toString();
       } else {
@@ -61,8 +62,8 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
   for (var i = 0; i < array.length; i++) {
     var val = array[i];
 
-    if (Array.isArray(val)) {
-      sql += (i === 0 ? '' : ', ') + '(' + SqlString.arrayToList(val, timeZone) + ')';
+    if (isIterable(val)) {
+      sql += (i === 0 ? '' : ', ') + '(' + SqlString.arrayToList(toArray(val), timeZone) + ')';
     } else {
       sql += (i === 0 ? '' : ', ') + SqlString.escape(val, true, timeZone);
     }
@@ -74,6 +75,10 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
 SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
   if (values == null) {
     return sql;
+  }
+
+  if (isIterable(values)) {
+    values = toArray(values);
   }
 
   if (!(values instanceof Array || Array.isArray(values))) {
@@ -210,4 +215,12 @@ function convertTimezone(tz) {
     return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
   }
   return false;
+}
+
+function isIterable(val) {
+  return typeof val !== 'string' && typeof val[Symbol.iterator] === 'function';
+}
+
+function toArray(val) {
+  return Array.from(val);
 }

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -244,23 +244,12 @@ function isMap(val) {
 }
 
 function toArray(val) {
-  if (!iterableSupport) return val;
-  if (Array.isArray(val)) return val;
-  if (typeof val.next === 'undefined') {
+  if (!iterableSupport || Array.isArray(val)) return val;
+  if (typeof Array.from === 'undefined') {
     var arr = [];
     val.forEach(function(key) {
       arr.push(key);
     });
-    return arr;
-  }
-  if (typeof Array.from === 'undefined') {
-    var arr = [];
-    var g;
-    while(true){
-      g = val.next();
-      if (g.done) break;
-      arr.push(g.value);
-    }
     return arr;
   }
   return Array.from(val);
@@ -279,6 +268,5 @@ function mapToObject(map) {
 }
 
 function isIterableSupported() {
-  if ('function' === typeof Map && 'function' === typeof Set) return true;
-  return false;
+  return 'function' === typeof Map && 'function' === typeof Set;
 }

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -11,9 +11,10 @@ var charsMap   = {
   '\'': '\\\'',
   '\\': '\\\\'
 };
+var mapInstance = new Map();
 
 SqlString.escapeId = function escapeId(val, forbidQualified) {
-  if (isIterable(val)) {
+  if (isArrayLike(val)) {
     val = toArray(val);
     var sql = '';
 
@@ -44,7 +45,7 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
         val = SqlString.dateToString(val, timeZone || 'local');
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
-      } else if (isIterable(val)) {
+      } else if (isArrayLike(val)) {
         return SqlString.arrayToList(toArray(val), timeZone);
       } else if (stringifyObjects) {
         val = val.toString();
@@ -62,7 +63,7 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
   for (var i = 0; i < array.length; i++) {
     var val = array[i];
 
-    if (isIterable(val)) {
+    if (isArrayLike(val)) {
       sql += (i === 0 ? '' : ', ') + '(' + SqlString.arrayToList(toArray(val), timeZone) + ')';
     } else {
       sql += (i === 0 ? '' : ', ') + SqlString.escape(val, true, timeZone);
@@ -77,8 +78,12 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
     return sql;
   }
 
-  if (isIterable(values)) {
+  if (isArrayLike(values)) {
     values = toArray(values);
+  }
+
+  if (values instanceof Map) {
+    values = mapToObject(values);
   }
 
   if (!(values instanceof Array || Array.isArray(values))) {
@@ -161,6 +166,10 @@ SqlString.bufferToString = function bufferToString(buffer) {
 SqlString.objectToValues = function objectToValues(object, timeZone) {
   var sql = '';
 
+  if (object instanceof Map) {
+    object = mapToObject(object);
+  }
+
   for (var key in object) {
     var val = object[key];
 
@@ -217,10 +226,24 @@ function convertTimezone(tz) {
   return false;
 }
 
-function isIterable(val) {
-  return typeof val !== 'string' && typeof val[Symbol.iterator] === 'function';
+function isArrayLike(val) {
+  return typeof val[Symbol.iterator] === 'function' &&
+         typeof val !== 'string' &&
+         !(val instanceof Map);
 }
 
 function toArray(val) {
   return Array.from(val);
+}
+
+function mapToObject(map) {
+  var object = {};
+  map.forEach(function(val, key) {
+    object[key] = val;
+  });
+  // if custom toString was implemented, attach to new object
+  if (map.toString !== mapInstance.toString) {
+    object.toString = map.toString.bind(object);
+  }
+  return object;
 }

--- a/test/common.js
+++ b/test/common.js
@@ -9,6 +9,8 @@ common.root = path.resolve(__dirname, '..', (process.env.TEST_COVERAGE || ''));
 // Export module
 common.SqlString = require(common.root + '/index');
 
+common.iterableSupport = isIterableSupported();
+
 // Setup coverage hook
 if (process.env.TEST_COVERAGE) {
   process.on('exit', function () {
@@ -25,4 +27,9 @@ function writeCoverage(coverage) {
   mkdirp.sync(path.dirname(out));
 
   fs.writeFileSync(out, JSON.stringify(coverage));
+}
+
+function isIterableSupported() {
+  if ('function' === typeof Map && 'function' === typeof Set) return true;
+  return false;
 }

--- a/test/common.js
+++ b/test/common.js
@@ -30,6 +30,5 @@ function writeCoverage(coverage) {
 }
 
 function isIterableSupported() {
-  if ('function' === typeof Map && 'function' === typeof Set) return true;
-  return false;
+  return 'function' === typeof Map && 'function' === typeof Set;
 }

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -60,6 +60,13 @@ test('SqlString.escape', {
     assert.equal(SqlString.escape({a: 'b', c: 'd'}), "`a` = 'b', `c` = 'd'");
   },
 
+  'maps are turned into key value pairs': function() {
+    var map = new Map();
+    map.set('a', 'b');
+    map.set('c', 'd');
+    assert.equal(SqlString.escape(map), "`a` = 'b', `c` = 'd'");
+  },
+
   'objects function properties are ignored': function() {
     assert.equal(SqlString.escape({a: 'b', c: function() {}}), "`a` = 'b'");
   },
@@ -254,11 +261,31 @@ test('SqlString.format', {
     assert.equal(sql, "`hello` = 'world'");
   },
 
+  'maps is converted to values': function () {
+    var map = new Map();
+    map.set('hello', 'world');
+    var sql = SqlString.format('?', map, false);
+    assert.equal(sql, "`hello` = 'world'");
+  },
+
   'objects is not converted to values': function () {
     var sql = SqlString.format('?', { 'hello': 'world' }, true);
     assert.equal(sql, "'[object Object]'");
 
     var sql = SqlString.format('?', { toString: function () { return 'hello'; } }, true);
+    assert.equal(sql, "'hello'");
+  },
+
+  'maps is not converted to values': function () {
+    var map = new Map();
+    map.set('hello', 'world');
+
+    var sql = SqlString.format('?', map, true);
+    assert.equal(sql, "'[object Object]'");
+
+    map.toString = function () { return 'hello'; };
+
+    var sql = SqlString.format('?', map, true);
     assert.equal(sql, "'hello'");
   },
 

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -25,6 +25,14 @@ test('SqlString.escapeId', {
     assert.equal(SqlString.escapeId(['a', 'b', 't.c']), "`a`, `b`, `t`.`c`");
   },
 
+  'sets are turned into lists': function() {
+    var set = new Set();
+    set.add('a');
+    set.add('b');
+    set.add('t.c');
+    assert.equal(SqlString.escapeId(set), "`a`, `b`, `t`.`c`");
+  },
+
   'nested arrays are flattened': function() {
     assert.equal(SqlString.escapeId(['a', ['b', ['t.c']]]), "`a`, `b`, `t`.`c`");
   }
@@ -64,8 +72,16 @@ test('SqlString.escape', {
     assert.equal(SqlString.escape([1, 2, 'c']), "1, 2, 'c'");
   },
 
+  'sets are turned into lists': function() {
+    assert.equal(SqlString.escape(new Set([1, 2, 'c'])), "1, 2, 'c'");
+  },
+
   'nested arrays are turned into grouped lists': function() {
     assert.equal(SqlString.escape([[1,2,3], [4,5,6], ['a', 'b', {nested: true}]]), "(1, 2, 3), (4, 5, 6), ('a', 'b', '[object Object]')");
+  },
+
+  'array of sets are turned into grouped lists': function() {
+    assert.equal(SqlString.escape([new Set([1,2,3]), new Set([4,5,6]), new Set(['a', 'b', {nested: true}])]), "(1, 2, 3), (4, 5, 6), ('a', 'b', '[object Object]')");
   },
 
   'nested objects inside arrays are cast to strings': function() {
@@ -191,6 +207,14 @@ test('SqlString.format', {
     assert.equal(sql, "'a' and 'b'");
   },
 
+  'question marks are replaced with escaped set values': function() {
+    var set = new Set();
+    set.add('a');
+    set.add('b');
+    var sql = SqlString.format('? and ?', set);
+    assert.equal(sql, "'a' and 'b'");
+  },
+
   'double quest marks are replaced with escaped id': function () {
     var sql = SqlString.format('SELECT * FROM ?? WHERE id = ?', ['table', 42]);
     assert.equal(sql, 'SELECT * FROM `table` WHERE id = 42');
@@ -203,6 +227,15 @@ test('SqlString.format', {
 
   'extra arguments are not used': function() {
     var sql = SqlString.format('? and ?', ['a', 'b', 'c']);
+    assert.equal(sql, "'a' and 'b'");
+  },
+
+  'extra arguments in a set are not used': function() {
+    var set = new Set();
+    set.add('a');
+    set.add('b');
+    set.add('c');
+    var sql = SqlString.format('? and ?', set);
     assert.equal(sql, "'a' and 'b'");
   },
 

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -1,6 +1,7 @@
-var assert    = require('assert');
-var SqlString = require('../common').SqlString;
-var test      = require('utest');
+var assert          = require('assert');
+var SqlString       = require('../common').SqlString;
+var test            = require('utest');
+var iterableSupport = require('../common').iterableSupport;
 
 test('SqlString.escapeId', {
   'value is quoted': function() {
@@ -26,6 +27,7 @@ test('SqlString.escapeId', {
   },
 
   'sets are turned into lists': function() {
+    if (!iterableSupport) return;
     var set = new Set();
     set.add('a');
     set.add('b');
@@ -61,6 +63,7 @@ test('SqlString.escape', {
   },
 
   'maps are turned into key value pairs': function() {
+    if (!iterableSupport) return;
     var map = new Map();
     map.set('a', 'b');
     map.set('c', 'd');
@@ -80,6 +83,7 @@ test('SqlString.escape', {
   },
 
   'sets are turned into lists': function() {
+    if (!iterableSupport) return;
     assert.equal(SqlString.escape(new Set([1, 2, 'c'])), "1, 2, 'c'");
   },
 
@@ -88,6 +92,7 @@ test('SqlString.escape', {
   },
 
   'array of sets are turned into grouped lists': function() {
+    if (!iterableSupport) return;
     assert.equal(SqlString.escape([new Set([1,2,3]), new Set([4,5,6]), new Set(['a', 'b', {nested: true}])]), "(1, 2, 3), (4, 5, 6), ('a', 'b', '[object Object]')");
   },
 
@@ -215,6 +220,7 @@ test('SqlString.format', {
   },
 
   'question marks are replaced with escaped set values': function() {
+    if (!iterableSupport) return;
     var set = new Set();
     set.add('a');
     set.add('b');
@@ -238,6 +244,7 @@ test('SqlString.format', {
   },
 
   'extra arguments in a set are not used': function() {
+    if (!iterableSupport) return;
     var set = new Set();
     set.add('a');
     set.add('b');
@@ -262,6 +269,7 @@ test('SqlString.format', {
   },
 
   'maps is converted to values': function () {
+    if (!iterableSupport) return;
     var map = new Map();
     map.set('hello', 'world');
     var sql = SqlString.format('?', map, false);
@@ -277,6 +285,7 @@ test('SqlString.format', {
   },
 
   'maps is not converted to values': function () {
+    if (!iterableSupport) return;
     var map = new Map();
     map.set('hello', 'world');
 


### PR DESCRIPTION
Attempts to implement support for es6 iterables like `Map` and `Set`, to fix [#1422](https://github.com/mysqljs/mysql/issues/1422).

`Set` should behave like an `Array`, `Map` should behave like an `Object`.
