### PR TITLE
Support number as field name

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -23,6 +23,10 @@ SqlString.escapeId = function escapeId(val, forbidQualified) {
     return sql;
   }
 
+  if (typeof val === 'number') {
+      val = String(val);
+  }
+
   if (forbidQualified) {
     return '`' + val.replace(/`/g, '``') + '`';
   }

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -23,15 +23,13 @@ SqlString.escapeId = function escapeId(val, forbidQualified) {
     return sql;
   }
 
-  if (typeof val === 'number') {
-      val = String(val);
-  }
+  var stringified = (typeof val === 'string') ? val : String(val);
 
   if (forbidQualified) {
-    return '`' + val.replace(/`/g, '``') + '`';
+    return '`' + stringified.replace(/`/g, '``') + '`';
   }
 
-  return '`' + val.replace(/`/g, '``').replace(/\./g, '`.`') + '`';
+  return '`' + stringified.replace(/`/g, '``').replace(/\./g, '`.`') + '`';
 };
 
 SqlString.escape = function escape(val, stringifyObjects, timeZone) {

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -27,6 +27,10 @@ test('SqlString.escapeId', {
 
   'nested arrays are flattened': function() {
     assert.equal(SqlString.escapeId(['a', ['b', ['t.c']]]), "`a`, `b`, `t`.`c`");
+  },
+
+  'number is escaped': function() {
+    assert.equal(SqlString.escapeId(1), "`1`");
   }
 });
 

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -30,7 +30,7 @@ test('SqlString.escapeId', {
   },
 
   'number is escaped': function() {
-    assert.equal(SqlString.escapeId(1), "`1`");
+    assert.equal(SqlString.escapeId(1), '`1`');
   }
 });
 


### PR DESCRIPTION
E.g.

```sql
CREATE TABLE `test` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `1` int(11) NOT NULL,
  `2` int(11) NOT NULL,
  `3` int(11) NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```

And my code would be like:

```javascript
let id = 5;
let idx = 1;
let sql = "UPDATE `test` SET ?? = ?? + (?) WHERE `id` = ?";
let params = [ idx, idx, 1, id ];
```