### PR TITLE
Add POINT(X, Y) support

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -45,6 +45,8 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
         return SqlString.arrayToList(val, timeZone);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
+      } else if (val.constructor.name === 'Point' && val.hasOwnProperty('x') && val.hasOwnProperty('y')) {
+        return 'POINT(' + [val.x, val.y].map(parseFloat).join(',') + ')';
       } else if (stringifyObjects) {
         val = val.toString();
       } else {

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -175,7 +175,7 @@ test('SqlString.escape', {
       this.y = y;
     }
 
-    var expected = 'POINT(123.004, -10.1)';
+    var expected = 'POINT(123.004,-10.1)';
     var input    = new Point(123.004, -10.1);
     var string   = SqlString.escape(input);
 

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -169,6 +169,19 @@ test('SqlString.escape', {
     assert.strictEqual(string, expected);
   },
 
+  'points are converted to POINT objects': function() {
+    function Point(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+
+    var expected = 'POINT(123.004, -10.1)';
+    var input    = new Point(123.004, -10.1);
+    var string   = SqlString.escape(input);
+
+    assert.strictEqual(string, expected);
+  },
+
   'buffers are converted to hex': function() {
     var buffer = new Buffer([0, 1, 254, 255]);
     var string = SqlString.escape(buffer);


### PR DESCRIPTION
Adds `POINT(x, y)` support. Assumes an object with constructor name 'Point'.

Can be easily added like so:
```js
// Simple:
function Point(x, y) {
    this.x = x;
    this.y = y;
}

// Verbose (ES6):
class Point {
    constructor(x, y) {
        this.x = x;
        this.y = y;
    }
}

// Escaping:
SqlString.escape(new Point(123, 456)); // -> POINT(123, 456)
```

I wrote it this way since, judging from the conversation in mysqljs/mysql#877, almost anything could break `SqlString.objectToValues(...)`.