### PR TITLE
Add `toSQL(dialect)` escaping support

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -45,6 +45,8 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
         return SqlString.arrayToList(val, timeZone);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
+      } else if (typeof val.toSQL === 'function') {
+        return val.toSQL('mysql');
       } else if (stringifyObjects) {
         val = val.toString();
       } else {

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -219,7 +219,7 @@ test('SqlString.escape', {
   'objects with toSQL() methods are passed "mysql" as first parameter': function() {
     function WithDialect() {
       this.toSQL = function(dialect) {
-        assert.strictEqual(string, 'mysql');
+        assert.strictEqual(dialect, 'mysql');
       }
     }
 

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -220,7 +220,7 @@ test('SqlString.escape', {
     function WithDialect() {
       this.toSQL = function(dialect) {
         assert.strictEqual(dialect, 'mysql');
-      }
+      };
     }
 
     var input    = new WithDialect();

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -188,6 +188,45 @@ test('SqlString.escape', {
     assert.strictEqual(string, "X'00\\' OR \\'1\\'=\\'1'");
   },
 
+  'native objects with toSQL() properties are escaped': function() {
+    var expected = 'some bad sql syntax';
+    var input    = {
+      toSQL: function() {
+        return expected;
+      }
+    };
+
+    var string = SqlString.escape(input);
+
+    assert.strictEqual(string, expected);
+  },
+
+  'class objects with toSQL() methods are escaped': function() {
+    var expected = 'more bad sql syntax';
+
+    function SomeClass() {}
+
+    SomeClass.prototype.toSQL = function() {
+      return expected;
+    };
+
+    var input    = new SomeClass();
+    var string   = SqlString.escape(input);
+
+    assert.strictEqual(string, expected);
+  },
+
+  'objects with toSQL() methods are passed "mysql" as first parameter': function() {
+    function WithDialect() {
+      this.toSQL = function(dialect) {
+        assert.strictEqual(string, 'mysql');
+      }
+    }
+
+    var input    = new WithDialect();
+    var string   = SqlString.escape(input);
+  },
+
   'NaN -> NaN': function() {
     assert.equal(SqlString.escape(NaN), 'NaN');
   },


### PR DESCRIPTION
Adds the ability to raw "escape" by passing an object which contains a `toSQL` method.

``` js
// ES5:
function Point(x, y) {
    this.x = x;
    this.y = y;
}

Point.prototype.toSQL = function (dialect) {
    switch (dialect) {
        case 'mysql':
           return 'POINT(' + [x, y].map(parseFloat).join(', ') + ')';

        ...
    }
}

SqlString.escape(new Point(123, 456)); // -> POINT(123, 456)
```

This is also great for generic function handling:

``` js
// ES6 Proxies:
const db = new Proxy({}, {
    get(target, name) {
        if (name in target) {
            return target[name];
        }

        return (...args) => ({
            toSQL() {
                const escapedArgs = args.map(SqlString.escape).join(', ');
                return `${name.toUpperCase()}(${escapedArgs})`;
            }
        });
    }
});

const a = db.POINT(123, 456);
const b = db.CURRENT_TIMESTAMP();
const c = db.CONCAT(db.UPPER('abc'), db.LOWER('ABC'));

SqlString.escape(a); // -> POINT(123, 456)
SqlString.escape(b); // -> CURRENT_TIMESTAMP()
SqlString.escape(c); // -> CONCAT(UPPER("abc"), LOWER("ABC"))
```

This is per the discussion on #8 with @dougwilson 
