### PR TITLE
Convert invalid dates to null

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -111,6 +111,10 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
 SqlString.dateToString = function dateToString(date, timeZone) {
   var dt = new Date(date);
 
+  if (isNaN(dt.getTime())) {
+      return null;
+  }
+
   var year;
   var month;
   var day;

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -173,6 +173,14 @@ test('SqlString.escape', {
     assert.strictEqual(string, expected);
   },
 
+  'invalid dates are converted to null': function() {
+    var date     = new Date('a');
+    var expected = null;
+    var string   = SqlString.escape(date);
+
+    assert.strictEqual(string, "'" + expected + "'");
+  },
+
   'buffers are converted to hex': function() {
     var buffer = new Buffer([0, 1, 254, 255]);
     var string = SqlString.escape(buffer);


### PR DESCRIPTION
So I had a case where I received an invalid date and did wrap it myself with `new Date()` but this module was parsing the invalid date to `0NaN-NaN-NaN NaN:NaN:NaN.NaN`.
Now I fixed this to be converted to null, what I assume is the behaviour people expect from the module but if this is not the case I am open for discussion ofc.

(Also looking forward to getting another beer with you like in Amsterdam, @dougwilson!)
