### PR TITLE
Map JavaScript undefined to MySQL DEFAULT

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Different value types are escaped differently, here is how:
   the object. If the property's value is a function, it is skipped; if the
   property's value is an object, toString() is called on it and the returned
   value is used.
-* `undefined` / `null` are converted to `NULL`
+* JavaScript `null` is converted to MySQL `NULL`
+* JavaScript `undefined` is converted to MySQL `DEFAULT`
 * `NaN` / `Infinity` are left as-is. MySQL does not support these, and trying
   to insert them as values will trigger MySQL errors until they implement
   support.

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -31,10 +31,14 @@ SqlString.escapeId = function escapeId(val, forbidQualified) {
 };
 
 SqlString.escape = function escape(val, stringifyObjects, timeZone) {
-  if (val === undefined || val === null) {
+  if (val === null) {
     return 'NULL';
   }
-
+  
+  if (val === undefined) {
+    return 'DEFAULT';
+  }
+  
   switch (typeof val) {
     case 'boolean': return (val) ? 'true' : 'false';
     case 'number': return val+'';


### PR DESCRIPTION
SqlString.escape maps both JavaScript `null` and `undefined` to MySQL `NULL`. This change proposes JavaScript `undefined` be mapped to MySQL `DEFAULT`, as per feature request mysqljs/mysql#559 and as discussed in mysqljs/mysql#1568.