### PR TITLE
Add `SqlString.fn` Function Call Proxy

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -45,8 +45,8 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
         return SqlString.arrayToList(val, timeZone);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
-      } else if (typeof val.toSQL === 'function') {
-        return val.toSQL('mysql');
+      } else if (val instanceof SqlFunction) {
+        return val.toSQL();
       } else if (stringifyObjects) {
         val = val.toString();
       } else {
@@ -170,6 +170,26 @@ SqlString.objectToValues = function objectToValues(object, timeZone) {
 
   return sql;
 };
+
+if (typeof Proxy === 'function') {
+  SqlString.fn = new Proxy({}, {
+    get(target, name) {
+      if (name in target) {
+        return target[name];
+      }
+
+      return (...args) => new SqlFunction(name, args);
+    }
+  });
+}
+
+function SqlFunction(name, args) {
+  const escapedArgs = args.map(SqlString.escape).join(', ');
+
+  this.toSQL() {
+    return `${name.toUpperCase()}(${escapedArgs})`;
+  };
+}
 
 function escapeString(val) {
   var chunkIndex = charsRegex.lastIndex = 0;

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -173,12 +173,16 @@ SqlString.objectToValues = function objectToValues(object, timeZone) {
 
 if (typeof Proxy === 'function') {
   SqlString.fn = new Proxy({}, {
-    get(target, name) {
+    get: function get(target, name) {
       if (name in target) {
         return target[name];
       }
 
-      return (...args) => new SqlFunction(name, args);
+      return function sqlFunctionHelper() {
+        const args = Array.prototype.slice.call(arguments);
+
+        return new SqlFunction(name, args);
+      };
     }
   });
 }
@@ -186,7 +190,7 @@ if (typeof Proxy === 'function') {
 function SqlFunction(name, args) {
   const escapedArgs = args.map(SqlString.escape).join(', ');
 
-  this.toSQL() {
+  this.toSQL = function toSQL() {
     return `${name.toUpperCase()}(${escapedArgs})`;
   };
 }

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -179,7 +179,7 @@ if (typeof Proxy === 'function') {
       }
 
       return function sqlFunctionHelper() {
-        const args = Array.prototype.slice.call(arguments);
+        var args = Array.prototype.slice.call(arguments);
 
         return new SqlFunction(name, args);
       };
@@ -188,7 +188,7 @@ if (typeof Proxy === 'function') {
 }
 
 function SqlFunction(name, args) {
-  const escapedArgs = args.map(SqlString.escape).join(', ');
+  var escapedArgs = args.map(SqlString.escape).join(', ');
 
   this.toSQL = function toSQL() {
     return name.toUpperCase() + '(' + escapedArgs + ')';

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -191,7 +191,7 @@ function SqlFunction(name, args) {
   const escapedArgs = args.map(SqlString.escape).join(', ');
 
   this.toSQL = function toSQL() {
-    return `${name.toUpperCase()}(${escapedArgs})`;
+    return name.toUpperCase() + '(' + escapedArgs + ')';
   };
 }
 

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -45,6 +45,8 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
         return SqlString.arrayToList(val, timeZone);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
+      } else if (typeof val.toSQL === 'function') {
+        return val.toSQL('mysql');
       } else if (stringifyObjects) {
         val = val.toString();
       } else {

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -216,17 +216,6 @@ test('SqlString.escape', {
     assert.strictEqual(string, expected);
   },
 
-  'objects with toSQL() methods are passed "mysql" as first parameter': function() {
-    function WithDialect() {
-      this.toSQL = function(dialect) {
-        assert.strictEqual(dialect, 'mysql');
-      };
-    }
-
-    var input    = new WithDialect();
-    var string   = SqlString.escape(input);
-  },
-
   'NaN -> NaN': function() {
     assert.equal(SqlString.escape(NaN), 'NaN');
   },

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -219,7 +219,7 @@ test('SqlString.escape', {
   'objects with toSQL() methods are passed "mysql" as first parameter': function() {
     function WithDialect() {
       this.toSQL = function(dialect) {
-        assert.strictEqual(string, 'mysql');
+        assert.strictEqual(dialect, 'mysql');
       }
     }
 

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -220,7 +220,7 @@ test('SqlString.escape', {
     function WithDialect() {
       this.toSQL = function(dialect) {
         assert.strictEqual(dialect, 'mysql');
-      }
+      };
     }
 
     var input    = new WithDialect();

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -201,7 +201,7 @@ test('SqlString.escape', {
     var b = SqlString.fn.CURRENT_TIMESTAMP();
 
     assert.strictEqual(SqlString.escape(a), 'POINT(123, 456)');
-    assert.strictEqual(SqlString.escape(b), 'CURRENT_TIMESTAMP');
+    assert.strictEqual(SqlString.escape(b), 'CURRENT_TIMESTAMP()');
   },
 
   'SqlString.fn escapes nested SQL functions properly, if Proxy is supported': function() {

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -188,6 +188,45 @@ test('SqlString.escape', {
     assert.strictEqual(string, "X'00\\' OR \\'1\\'=\\'1'");
   },
 
+  'native objects with toSQL() properties are escaped': function() {
+    var expected = 'some bad sql syntax';
+    var input    = {
+      toSQL: function() {
+        return expected;
+      }
+    };
+
+    var string = SqlString.escape(input);
+
+    assert.strictEqual(string, expected);
+  },
+
+  'class objects with toSQL() methods are escaped': function() {
+    var expected = 'more bad sql syntax';
+
+    function SomeClass() {}
+
+    SomeClass.prototype.toSQL = function() {
+      return expected;
+    };
+
+    var input    = new SomeClass();
+    var string   = SqlString.escape(input);
+
+    assert.strictEqual(string, expected);
+  },
+
+  'objects with toSQL() methods are passed "mysql" as first parameter': function() {
+    function WithDialect() {
+      this.toSQL = function(dialect) {
+        assert.strictEqual(string, 'mysql');
+      }
+    }
+
+    var input    = new WithDialect();
+    var string   = SqlString.escape(input);
+  },
+
   'NaN -> NaN': function() {
     assert.equal(SqlString.escape(NaN), 'NaN');
   },

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -211,7 +211,7 @@ test('SqlString.escape', {
 
     var fn = SqlString.fn.CONCAT(SqlString.fn.UPPER('abc'), SqlString.fn.LOWER('ABC'));
 
-    assert.strictEqual(SqlString.escape(fn), 'CONCAT(UPPER("abc"), LOWER("ABC"))');
+    assert.strictEqual(SqlString.escape(fn), "CONCAT(UPPER('abc'), LOWER('ABC'))");
   },
 
   'NaN -> NaN': function() {


### PR DESCRIPTION
Adds the ability to raw "escape" by calling any `SqlString.fn.*` property as a function.

It takes the Proxy example from #9 and merges it in directly into the library.

It only works on Node.js v6+ (according to [node.green](http://node.green)), but there is a check so that users of lower versions can use the library (without `SqlString.fn.*` support), which is a con #9 didn't have..

Examples:
```js
const a = SqlString.fn.POINT(123, 456);
const b = SqlString.fn.CURRENT_TIMESTAMP();
const c = SqlString.fn.CONCAT(SqlString.fn.UPPER('abc'), SqlString.fn.LOWER('ABC'));

SqlString.escape(a); // -> POINT(123, 456)
SqlString.escape(b); // -> CURRENT_TIMESTAMP()
SqlString.escape(c); // -> CONCAT(UPPER("abc"), LOWER("ABC"))
```

Should be a lot more secure than #9, since the escape function checks if the value from the `SqlString.fn.*` call is in an instance of an internal function class (`SqlFunction`) that doesn't get exported. It also escapes all arguments.

Playing (security) devils advocate:
- If someone has external influence on `SqlString.fn` or `SqlString.escape`, you're screwed.
- If someone has external influence on `Array.prototype.map`, you're screwed.
- If someone has external influence on the global Proxy class, you're screwed.
- If someone has external influence on your app, you're screwed.