### PR TITLE
Named Placeholder Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ console.log(sql); // UPDATE users SET foo = 'a', bar = 'b', baz = 'c' WHERE id =
 This looks similar to prepared statements in MySQL, however it really just uses
 the same `SqlString.escape()` method internally.
 
+Alternatively, you can use named placeholders and pass in an object for the values:
+
+```js
+var userId = 1;
+var sql    = SqlString.format('UPDATE users SET foo = :foo, bar = :bar, baz = :baz WHERE id = :id',
+  {a: 'a', b: 'b', c: 'c', id: userId});
+console.log(sql); // UPDATE users SET foo = 'a', bar = 'b', baz = 'c' WHERE id = 1
+```
+
 **Caution** This also differs from prepared statements in that all `?` are
 replaced, even those contained in comments and strings.
 
@@ -136,6 +145,15 @@ console.log(sql); // SELECT `username`, `email` FROM `users` WHERE id = 1
 **Please note that this last character sequence is experimental and syntax might change**
 
 When you pass an Object to `.escape()` or `.format()`, `.escapeId()` is used to avoid SQL injection in object keys.
+
+Alternatively, you can use named placeholders (pre fixed with 2 colons) for identifiers and pass in an object for the values:
+
+```js
+var userId = 1;
+var columns = ['username', 'email'];
+var sql     = SqlString.format('SELECT ::columns FROM ::table WHERE id = :id', {columns: columns, table: 'users', id: userId});
+console.log(sql); // SELECT `username`, `email` FROM `users` WHERE id = 1
+```
 
 ### Formatting queries
 

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -72,7 +72,7 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
 
 SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
 
-  var namedPattern = /(::?)([a-z_\-0-9]+)/ig;
+  var namedPattern = /::?[a-z_\-0-9]+/ig;
   var namedPlaceholders = sql.match(namedPattern) || [];
   var isObjectParams = values && values.constructor === Object;
 

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -71,6 +71,28 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
 };
 
 SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
+
+  var namedPattern = /(::?)([a-z_\-0-9]+)/ig;
+  var namedPlaceholders = sql.match(namedPattern) || [];
+  var isObjectParams = values && values.constructor === Object;
+
+  if (namedPlaceholders.length && isObjectParams) {
+    if (Object.keys(values).length) {
+      // Extract object values in the correct order
+      values = namedPlaceholders.reduce(function (list, placeHolder) {
+        var isIdentifier = /^::/.test(placeHolder);
+        var key = placeHolder.replace(/^:+/, '');
+        if (key in values) {
+          sql = sql.replace(placeHolder, isIdentifier ? '??' : '?');
+          list.push(values[key]);
+        }
+        return list;
+      }, []);
+    } else {
+      values = null;
+    }
+  }
+
   if (values == null) {
     return sql;
   }
@@ -87,8 +109,8 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
 
   while (valuesIndex < values.length && (match = placeholdersRegex.exec(sql))) {
     var value = match[0] === '??'
-        ? SqlString.escapeId(values[valuesIndex])
-        : SqlString.escape(values[valuesIndex], stringifyObjects, timeZone);
+      ? SqlString.escapeId(values[valuesIndex])
+      : SqlString.escape(values[valuesIndex], stringifyObjects, timeZone);
 
     result += sql.slice(chunkIndex, match.index) + value;
     chunkIndex = placeholdersRegex.lastIndex;

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -258,5 +258,45 @@ test('SqlString.format', {
   'sql is untouched if values are provided but there are no placeholders': function () {
     var sql = SqlString.format('SELECT COUNT(*) FROM table', ['a', 'b']);
     assert.equal(sql, 'SELECT COUNT(*) FROM table');
+  },
+  // Named placeholder tests
+  'named placeholders should be replaced with values if values are provided': function () {
+    var sql = SqlString.format('SELECT * FROM ::table WHERE hello = :world AND foo = :bar AND ::world IN [:worlds]', {table: 'tester', bar: 'bar', world: 'world', worlds: ['earth', 'mars']});
+    assert.equal(sql, "SELECT * FROM `tester` WHERE hello = 'world' AND foo = 'bar' AND `world` IN ['earth', 'mars']");
+  },
+
+  'question mark placeholders values that contain colons do not cause issues': function() {
+    var sql = SqlString.format('? and ?', [':hello', '::b']);
+    assert.equal(sql, "':hello' and '::b'");
+  },
+
+  'named placeholders with values that contain colons do not cause issues': function() {
+    var sql = SqlString.format(':a and ::b', {a: ':hello', b: '::b'});
+    assert.equal(sql, "':hello' and `::b`");
+  },
+
+  'named placeholders with values that contain question marks do not cause issues': function() {
+    var sql = SqlString.format(':a and :b', {a: 'hello?', b: 'b'});
+    assert.equal(sql, "'hello?' and 'b'");
+  },
+
+  'extra named placeholders are left un-touched': function() {
+    var sql = SqlString.format(':a and :b and :c and ::c and :b and ::a', {a: 'a', c: 'c'});
+    assert.equal(sql, "'a' and :b and 'c' and `c` and :b and `a`");
+  },
+
+  'name placeholders are left un-touched and question marks are replace when an array is specified': function() {
+    var sql = SqlString.format('SELECT * FROM ?? WHERE a = ? AND b = :b AND c = ?', ['tester', 'a', 'c']);
+    assert.equal(sql, "SELECT * FROM `tester` WHERE a = 'a' AND b = :b AND c = 'c'");
+  },
+
+  'name placeholders are left un-touched and question marks are replace when a single value is specified': function() {
+    var sql = SqlString.format('SELECT * FROM tester WHERE a = ? AND b = :b', 'a');
+    assert.equal(sql, "SELECT * FROM tester WHERE a = 'a' AND b = :b");
+  },
+
+  'name placeholders are replace for columns': function() {
+    var sql = SqlString.format('SELECT ::columns FROM ::table WHERE id = :id', {columns: ['username', 'email'], table: 'users', id: 1});
+    assert.equal(sql, "SELECT `username`, `email` FROM `users` WHERE id = 1");
   }
 });

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -303,5 +303,5 @@ test('SqlString.format', {
   'named placeholders are left un-touched when empty object is passed for values': function() {
     var sql = SqlString.format(':a and :b and :c and ::c and :b and ::a', {});
     assert.equal(sql, ":a and :b and :c and ::c and :b and ::a");
-  },
+  }
 });

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -298,5 +298,10 @@ test('SqlString.format', {
   'name placeholders are replace for columns': function() {
     var sql = SqlString.format('SELECT ::columns FROM ::table WHERE id = :id', {columns: ['username', 'email'], table: 'users', id: 1});
     assert.equal(sql, "SELECT `username`, `email` FROM `users` WHERE id = 1");
-  }
+  },
+
+  'named placeholders are left un-touched when empty object is passed for values': function() {
+    var sql = SqlString.format(':a and :b and :c and ::c and :b and ::a', {});
+    assert.equal(sql, ":a and :b and :c and ::c and :b and ::a");
+  },
 });


### PR DESCRIPTION
Hi,

I would like to add named placeholder support so that the order of values don't matter and so that I can reuse the same value multiple times but only specify it once.

The basic idea is this:

```js
const sql = SqlString.format('SELECT ::columns FROM ::table WHERE id = :id', {
    id: 1,
    columns: ['username', 'email'], 
    table: 'users'
});
console.log(sql); // SELECT `username`, `email` FROM `users` WHERE id = 1
```

Please see the attached diff.

Thanks,

Craig