### PR TITLE
SqlString.escapeString  - Remove single quotes from return values.

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -186,14 +186,14 @@ function escapeString(val) {
 
   if (chunkIndex === 0) {
     // Nothing was escaped
-    return "'" + val + "'";
+    return val;
   }
 
   if (chunkIndex < val.length) {
-    return "'" + escapedVal + val.slice(chunkIndex) + "'";
+    return escapedVal + val.slice(chunkIndex);
   }
 
-  return "'" + escapedVal + "'";
+  return escapedVal;
 }
 
 function zeroPad(number, length) {


### PR DESCRIPTION
For example, when I escape a username input I want to return Jake as opposed to 'Jake'.