### PR TITLE
Add `and` separator option for `escape()` and as placeholder option in `format()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ console.log(sql); // SELECT `username`, `email` FROM `users` WHERE id = 1
 
 When you pass an Object to `.escape()` or `.format()`, `.escapeId()` is used to avoid SQL injection in object keys.
 
+#### AND separation in WHERE clauses
+You can use the `?&` placeholder to insert the word `and` instead of separating object lists or arrays with commas. Typically in SQL the WHERE clause uses `and` and `or` separators (the `or` separator is not supported with this placeholder.) SELECT field lists and SET assignment lists require the comma as a separator. The `SqlString.format()` parser will accept a `?&` placeholder to indicate when to use the `and` separator over the comma. The `SqlString.escape()` function now accepts an optional fourth boolean parameter to indicate if an ` and ` should be used to separate object lists and arrays instead of the default comma `, `. This applies to nested lists as well.
+
+```js
+var sql = SqlString.format('UPDATE ?? SET ? WHERE ?&', ['table',{name:'My Name',updated:'Y','status code':'z'}, {id:15,active:'Y'}]);
+console.log(sql); // UPDATE `table` SET `name` = 'My Name', `updated` = 'Y', `status code` = 'z' WHERE `id` = 15 and `active` = 'Y'
+```
+
+```
+var sql = SqlString.format('SELECT ?? FROM ?? WHERE ?&', [['col1','col 2'],'table', {id:15,active:'Y'}]);
+console.log(sql); // SELECT `col1`, `col 2` FROM `table` WHERE `id` = 15 and `active` = 'Y'
+```
+
 ### Formatting queries
 
 You can use `SqlString.format` to prepare a query with multiple insertion points,

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -31,7 +31,7 @@ SqlString.escapeId = function escapeId(val, forbidQualified) {
   }
 };
 
-SqlString.escape = function escape(val, stringifyObjects, timeZone) {
+SqlString.escape = function escape(val, stringifyObjects, timeZone, useAndFlag) {
   if (val === undefined || val === null) {
     return 'NULL';
   }
@@ -43,7 +43,7 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
       if (val instanceof Date) {
         return SqlString.dateToString(val, timeZone || 'local');
       } else if (Array.isArray(val)) {
-        return SqlString.arrayToList(val, timeZone);
+        return SqlString.arrayToList(val, timeZone, useAndFlag);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
       } else if (typeof val.toSqlString === 'function') {
@@ -51,22 +51,23 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
       } else if (stringifyObjects) {
         return escapeString(val.toString());
       } else {
-        return SqlString.objectToValues(val, timeZone);
+        return SqlString.objectToValues(val, timeZone,useAndFlag);
       }
     default: return escapeString(val);
   }
 };
 
-SqlString.arrayToList = function arrayToList(array, timeZone) {
+SqlString.arrayToList = function arrayToList(array, timeZone, useAndFlag) {
   var sql = '';
+  var separator = (useAndFlag) ? ' and ' : ', ';
 
   for (var i = 0; i < array.length; i++) {
     var val = array[i];
 
     if (Array.isArray(val)) {
-      sql += (i === 0 ? '' : ', ') + '(' + SqlString.arrayToList(val, timeZone) + ')';
+      sql += (i === 0 ? '' : separator) + '(' + SqlString.arrayToList(val, timeZone, useAndFlag) + ')';
     } else {
-      sql += (i === 0 ? '' : ', ') + SqlString.escape(val, true, timeZone);
+      sql += (i === 0 ? '' : separator) + SqlString.escape(val, true, timeZone, useAndFlag);
     }
   }
 
@@ -83,7 +84,7 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
   }
 
   var chunkIndex        = 0;
-  var placeholdersRegex = /\?+/g;
+  var placeholdersRegex = /\?+&?/g; // matches ?, ?? ?& and ??& but those over 2 chars are ignored
   var result            = '';
   var valuesIndex       = 0;
   var match;
@@ -94,10 +95,10 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
     if (len > 2) {
       continue;
     }
-
-    var value = len === 2
+    var useAndFlag = (match[0] === '?&');
+    var value = (len === 2 && !useAndFlag)
       ? SqlString.escapeId(values[valuesIndex])
-      : SqlString.escape(values[valuesIndex], stringifyObjects, timeZone);
+      : SqlString.escape(values[valuesIndex], stringifyObjects, timeZone, useAndFlag);
 
     result += sql.slice(chunkIndex, match.index) + value;
     chunkIndex = placeholdersRegex.lastIndex;
@@ -167,8 +168,9 @@ SqlString.bufferToString = function bufferToString(buffer) {
   return 'X' + escapeString(buffer.toString('hex'));
 };
 
-SqlString.objectToValues = function objectToValues(object, timeZone) {
+SqlString.objectToValues = function objectToValues(object, timeZone,useAndFlag) {
   var sql = '';
+  var separator = (useAndFlag) ? ' and ' : ', ';
 
   for (var key in object) {
     var val = object[key];
@@ -177,7 +179,7 @@ SqlString.objectToValues = function objectToValues(object, timeZone) {
       continue;
     }
 
-    sql += (sql.length === 0 ? '' : ', ') + SqlString.escapeId(key) + ' = ' + SqlString.escape(val, true, timeZone);
+    sql += (sql.length === 0 ? '' : separator) + SqlString.escapeId(key) + ' = ' + SqlString.escape(val, true, timeZone);
   }
 
   return sql;

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -74,6 +74,10 @@ test('SqlString.escape', {
     assert.equal(SqlString.escape({a: 'b', c: 'd'}), "`a` = 'b', `c` = 'd'");
   },
 
+  'objects are turned into key value pairs with and separators': function() {
+    assert.equal(SqlString.escape({key1: 5, 'key 2': 'two words'},undefined,undefined,true), "`key1` = 5 and `key 2` = 'two words'");
+  },
+
   'objects function properties are ignored': function() {
     assert.equal(SqlString.escape({a: 'b', c: function() {}}), "`a` = 'b'");
   },
@@ -108,6 +112,10 @@ test('SqlString.escape', {
 
   'nested arrays are turned into grouped lists': function() {
     assert.equal(SqlString.escape([[1, 2, 3], [4, 5, 6], ['a', 'b', {nested: true}]]), "(1, 2, 3), (4, 5, 6), ('a', 'b', '[object Object]')");
+  },
+
+  'nested arrays are turned into grouped lists with and separators': function() {
+    assert.equal(SqlString.escape([[1, 2, 3], [4, 5, 6], ['a', 'b', {nested: true}]],undefined,undefined,true), "(1 and 2 and 3) and (4 and 5 and 6) and ('a' and 'b' and '[object Object]')");
   },
 
   'nested objects inside arrays are cast to strings': function() {
@@ -255,6 +263,16 @@ test('SqlString.format', {
   'double quest marks are replaced with escaped id': function () {
     var sql = SqlString.format('SELECT * FROM ?? WHERE id = ?', ['table', 42]);
     assert.equal(sql, 'SELECT * FROM `table` WHERE id = 42');
+  },
+
+  'question mark and ampersand together are replaced with escaped array values separated with and when more than one value is present': function () {
+    var sql = SqlString.format('SELECT ?? FROM ?? WHERE ?&', [['col1','col 2'],'table', {id:15,active:'Y'}]);
+    assert.equal(sql, 'SELECT `col1`, `col 2` FROM `table` WHERE `id` = 15 and `active` = \'Y\'');
+  },
+
+  'single question mark, double question mark and question mark and ampersand together are replaced with escaped array values separated with and when more than one value is present': function () {
+    var sql = SqlString.format('UPDATE ?? SET ? WHERE ?&', ['table',{name:'My Name',updated:'Y','status code':'z'}, {id:15,active:'Y'}]);
+    assert.equal(sql, 'UPDATE `table` SET `name` = \'My Name\', `updated` = \'Y\', `status code` = \'z\' WHERE `id` = 15 and `active` = \'Y\'');
   },
 
   'triple question marks are ignored': function () {


### PR DESCRIPTION
There is no support for dynamic object list expansion in the WHERE clause using this library. I added a new placeholder `?&` that tells the `.escape()` function via a fourth parameter to use the word `and` instead of the default `,` to separate lists of values or arrays of objects. This allows the use of lists of objects in the WHERE clause correctly.
This addresses this issue in stackoverflow: https://stackoverflow.com/questions/45380149/node-mysql-multiple-where-with-and-clause

