### PR TITLE
Remove outdated perf optimization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * perf: remove outdated array pattern
+
 2.3.1 / 2018-02-24
 ==================
 

--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -78,7 +78,7 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
     return sql;
   }
 
-  if (!(values instanceof Array || Array.isArray(values))) {
+  if (!Array.isArray(values)) {
     values = [values];
   }
 


### PR DESCRIPTION
I added this perf optimization a while ago (can't find a reference since it was before the repo was moved here). It's now outdated since `Array.isArray()` is as fast as or faster than `instanceof Array`. Keeping it around for older versions of Node wouldn't be useful since it's such a small perf improvement compared to the fact that it's basically unnecessary, duplicated code.